### PR TITLE
Add Pillow dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mediapipe==0.10.7
 opencv-python==4.9.0.80
 scikit-learn==1.4.1
 numpy==1.26.4
+Pillow


### PR DESCRIPTION
## Summary
- add Pillow to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement mediapipe==0.10.7 due to proxy or connectivity issues)*

------
https://chatgpt.com/codex/tasks/task_e_688c174c6554832b97b715db1f750ab6